### PR TITLE
Deprecated classes removed

### DIFF
--- a/nudity/__init__.py
+++ b/nudity/__init__.py
@@ -22,10 +22,10 @@ class Nudity:
         self.output_operation = self.graph.get_operation_by_name(output_name);
 
     def read_tensor_from_image_file(self, file_name, input_height=299, input_width=299,
-    				input_mean=0, input_std=255):
+            input_mean=0, input_std=255):
       input_name = "file_reader"
       output_name = "normalized"
-      file_reader = tf.read_file(file_name, input_name)
+      file_reader = tf.io.read_file(file_name, input_name)
       if file_name.endswith(".png"):
         image_reader = tf.image.decode_png(file_reader, channels = 3,
                                            name='png_reader')
@@ -39,16 +39,16 @@ class Nudity:
                                             name='jpeg_reader')
       float_caster = tf.cast(image_reader, tf.float32)
       dims_expander = tf.expand_dims(float_caster, 0);
-      resized = tf.image.resize_bilinear(dims_expander, [input_height, input_width])
+      resized = tf.compat.v1.image.resize_bilinear(dims_expander, [input_height, input_width])
       normalized = tf.divide(tf.subtract(resized, [input_mean]), [input_std])
-      sess = tf.Session()
+      sess = tf.compat.v1.Session()
       result = sess.run(normalized)
 
       return result
 
     def load_graph(self, model_file):
         graph = tf.Graph()
-        graph_def = tf.GraphDef()
+        graph_def = tf.compat.v1.GraphDef()
         with open(model_file, "rb") as f:
             graph_def.ParseFromString(f.read())
         with graph.as_default():
@@ -61,7 +61,7 @@ class Nudity:
                                         input_width=self.input_width,
                                         input_mean=self.input_mean,
                                         input_std=self.input_std)
-        with tf.Session(graph=self.graph) as sess:
+        with tf.compat.v1.Session(graph=self.graph) as sess:
           results = sess.run(self.output_operation.outputs[0],
                             {self.input_operation.outputs[0]: t})
         results = np.squeeze(results)


### PR DESCRIPTION
Using tf.compat.v1.GraphDef instead of tf.GraphDef (deprecated).
Using tf.io.read_file instead of tf.read_file (deprecated).
Using tf.compat.v1.image.resize_bilinear instead of tf.image.resize_bilinear (deprecated).
Using tf.compat.v1.Session instead of tf.Session (deprecated).